### PR TITLE
define STRICT_R_HEADERS, include float.h

### DIFF
--- a/src/bin2dec_Rcpp.cpp
+++ b/src/bin2dec_Rcpp.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 using namespace Rcpp;
 

--- a/src/rks_Rcpp.cpp
+++ b/src/rks_Rcpp.cpp
@@ -1,3 +1,5 @@
+#define STRICT_R_HEADERS
+#include <float.h>
 #include <Rcpp.h>
 using namespace Rcpp;
 


### PR DESCRIPTION
Dear Jonathan,

Your CRAN package blatent uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at
  https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context on this.

Here, I prefixed two #include <Rcpp.h> with STRICT_R_HEADERS which is slightly more extensive then we need to, but it ensures we will not get surprised later. If you prefer, we can remove one in this PR. The one change that is needed is the change to also (explicitly) `#include <float.h>` so that `DBL_EPSILON` is defined (which seemingly to longer happens automatically when setting `STRICT_R_HEADERS`.  No other changes were made.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
  https://github.com/RcppCore/Rcpp/issues/1158
to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.